### PR TITLE
Make github-repository param optional

### DIFF
--- a/.github/workflows/ansible-galaxy-import.yml
+++ b/.github/workflows/ansible-galaxy-import.yml
@@ -5,7 +5,7 @@ on:
       github-repository:
         type: string
         description: The owner and repository name. For example gantsign/ansible-role-java.
-        required: true
+        required: false
         default: '${{ github.repository }}'
 env:
   ANSIBLE_FORCE_COLOR: '1'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: gantsign:workflows/.github/workflows/ansible-galaxy-import.yml@v1
+    uses: gantsign/workflows/.github/workflows/ansible-galaxy-import.yml@v1
     secrets: inherit
 ```
 


### PR DESCRIPTION
It has a default value, so it doesn't need to be required.